### PR TITLE
Specify the minimum ruby version required.

### DIFF
--- a/ripe-db.gemspec
+++ b/ripe-db.gemspec
@@ -11,4 +11,5 @@ Gem::Specification.new do |s|
   s.authors       = ["Adam Cooke"]
   s.email         = ["me@adamcooke.io"]
   s.licenses      = ['MIT']
+  s.required_ruby_version = '>= 2.3'
 end


### PR DESCRIPTION
The gem cleanly installs on Ruby < 2.3, but since the lonely (&.) operator was introduced in Ruby 2.3, you just get a bunch of syntax errors on older rubies.